### PR TITLE
Fixed datatype naming differences

### DIFF
--- a/create_landing_pages.py
+++ b/create_landing_pages.py
@@ -7,7 +7,7 @@ page_content = {
         "title": "Analytics and Query API",
         "description": "Query and analyze data logged to W&B.",
     },
-    "data-types": {
+    "data-type": {
         "title": "Data Types",
         "description": "Defines Data Types for logging interactive visualizations to W&B.",
     },

--- a/generate_sdk_docs.py
+++ b/generate_sdk_docs.py
@@ -95,8 +95,8 @@ def _title_key_string(docodile):
 
 def _type_key_string(docodile):
     """Determine the type of the object and return the appropriate frontmatter string."""
-    if "sdk" and "data_type" in docodile.getfile_path:
-        return "object_type: data_type\n"
+    if "sdk" and "data_type" in docodile.getfile_path: # Careful with data-type and data_type
+        return "object_type: data-type\n"
     elif "apis" and "public" in docodile.getfile_path:
         return "object_type: public_apis_namespace\n"
     elif "launch" in docodile.getfile_path:

--- a/sort_markdown_files.py
+++ b/sort_markdown_files.py
@@ -14,7 +14,7 @@ def main(args):
     # # Define object_type to subfolder mapping
     type_to_subfolder = {
         "api": "actions",
-        "data_type": "data-types",
+        "data-type": "data-type",
         "public_apis_namespace": "public-api",
         "launch_apis_namespace": "launch-library",  
         #"launch_apis_namespace": os.path.join("actions", "launch-library"),  # Make it a subdirectory under actions


### PR DESCRIPTION
Today's data type path uses a dash, instead of an underscore. Not idea (for Python reasons) but I am using it to keep, reduce the discrepancy.