### PR TITLE
Keep _index.md files [Demo working]

### DIFF
--- a/create_wandb_sdk_docs.sh
+++ b/create_wandb_sdk_docs.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
 TEMP_DIR=wandb_sdk_docs
-DESTINATION_DIR=python-library
-HUGO_DIR=/Users/noahluna/Desktop/RandomProjects/docs/content/ref/
+SRC=python-library
+DEST=/Users/noahluna/Desktop/RandomProjects/docs/content/ref/
 
 # Remove current docs in sdk_docs_temp
 rm -rf $TEMP_DIR/*.md
 
+# Remove output directory if it exists
+if [ -d "$SRC" ]; then
+    rm -rf $SRC
+fi
+
 # Remove current docs in Hugo directory
-rm -rf $HUGO_DIR/$DESTINATION_DIR
+#rm -rf $DEST/$SRC
 
 # Generate SDK docs using lazydocs
 python generate_sdk_docs.py --temp_output_directory=$TEMP_DIR
@@ -17,20 +22,35 @@ python generate_sdk_docs.py --temp_output_directory=$TEMP_DIR
 python process_sdk_markdown.py --output_directory=$TEMP_DIR
 
 # Make destination directory
-mkdir -p $DESTINATION_DIR
+mkdir -p $SRC
 
 # Sort and create subdirectories based on API or DataType
-python sort_markdown_files.py --source_directory=$TEMP_DIR --destination_directory=$DESTINATION_DIR
+python sort_markdown_files.py --source_directory=$TEMP_DIR --destination_directory=$SRC
 
 # Create _index.md files
-python create_landing_pages.py --source_directory=$DESTINATION_DIR
+python create_landing_pages.py --source_directory=$SRC
 
 # Move local file with subdirs to Hugo directory
 #echo "Moving files to Hugo directory"
-mv $DESTINATION_DIR $HUGO_DIR
+#mv $SRC $DEST
 
 # TO DO: Clean this up
 # Rename README.md to _index.md and move to Hugo directory
 # echo "Moving _index.md"
 # mv $TEMP_DIR/README.md $TEMP_DIR/_index.md 
 # mv $TEMP_DIR/_index.md $HUGO_DIR/$DESTINATION_DIR
+
+# Step 1: Rsync everything EXCEPT _index.md at any depth
+rsync -a --filter='- **/_index.md' "$SRC" "$DEST"
+
+# Step 2: Manually copy _index.md files ONLY where they don't already exist
+find "$SRC" -type f -name '_index.md' | while read -r src_file; do
+    # Compute relative path from folderA
+    rel_path="${src_file#$SRC/}"
+    dest_file="$DEST/$(basename "$SRC")/$rel_path"
+
+    if [[ ! -f "$dest_file" ]]; then
+        mkdir -p "$(dirname "$dest_file")"
+        cp "$src_file" "$dest_file"
+    fi
+done


### PR DESCRIPTION
This modifies the bash script so it doesn't overwrite _index.md files in the destination folder (e.g. wandb/docs/ref/python) if it already exists. 