### PR TITLE
Change the title from Query API to Public API

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -40,7 +40,7 @@ SOURCE = {
         "module": "wandb.apis.public",
         "file_path": BASE_DIR / "wandb" / "wandb" / "apis" / "public" / "__init__.py",
         "hugo_specs": {
-            "title": "Query API",
+            "title": "Public API",
             "description": "Query and analyze data logged to W&B.",
             "frontmatter": "object_type: public_apis_namespace",
             "folder_name": "public-api",

--- a/create_landing_pages.py
+++ b/create_landing_pages.py
@@ -87,7 +87,7 @@ def create_python_index_file(filepath, page_content):
     """Create an _index.md file for the top-level python folder."""
 
     index_file = os.path.join(filepath, "_index.md")
-    title = f"Python Library v({wandb.__version__})"
+    title = f"Python Library v{wandb.__version__}"
 
     # Generate cards dynamically from page_content
     card_blocks = []


### PR DESCRIPTION
Update the Python reference generation scripts to rename the Python public API landing page, and to remove the parentheses from the page title in the Python reference landing page. This makes a manual update in the Docs repo permanent.

Ready for peer review.

Ref:
https://weightsandbiases.slack.com/archives/C01DX8LRZEJ/p1755665133088349
https://github.com/wandb/docs/pull/1543 for the one-off content update