### PR TITLE
Update title of public-api landing page going forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Why does this exist?
 - `/wandb_sdk_docs/` - Temporary directory for initial lazydocs output
 - `/python/` - Final organized documentation with subdirectories:
   - `/sdk/` - Core SDK functions and classes
-  - `/public-api/` - Query API documentation
+  - `/public-api/` - Public API documentation
   - `/automations/` - Automation features
   - `/data-types/` - Data type definitions
   - `/custom-charts/` - Chart visualization tools

--- a/configuration.py
+++ b/configuration.py
@@ -40,7 +40,7 @@ SOURCE = {
         "module": "wandb.apis.public",
         "file_path": BASE_DIR / "wandb" / "wandb" / "apis" / "public" / "__init__.py",
         "hugo_specs": {
-            "title": "Query API",
+            "title": "Public API",
             "description": "Query and analyze data logged to W&B.",
             "frontmatter": "object_type: public_apis_namespace",
             "folder_name": "public-api",


### PR DESCRIPTION
Update title of public-api landing page from Query API to Public API

Relates to https://github.com/wandb/docs/pull/1543 and makes it durable

Ready for review